### PR TITLE
投稿削除機能実装

### DIFF
--- a/app/controllers/api/bookmarks_controller.rb
+++ b/app/controllers/api/bookmarks_controller.rb
@@ -1,5 +1,5 @@
 class Api::BookmarksController < ApplicationController
-  protect_from_forgery :except => [:create]
+  protect_from_forgery :except => [:create, :destroy]
 
   def index
     @bookmarks = Bookmark.order('created_at DESC')
@@ -14,6 +14,15 @@ class Api::BookmarksController < ApplicationController
     @bookmark = Bookmark.new(bookmark_params)
     if @bookmark.save
       render :show, status: :created
+    else
+      render json: @bookmark.errors, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @bookmark = Bookmark.find(params[:id])
+    if @bookmark.destroy
+      render json: { json: 'Bookmark was successfully deleted.'}
     else
       render json: @bookmark.errors, status: :unprocessable_entity
     end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -21,7 +21,7 @@
                   </div>
                 </v-card-title>
                 <v-card-actions>
-                  <v-btn dark>DELETE</v-btn>
+                  <v-btn dark @click="deleteBookmark(bookmark.id)">DELETE</v-btn>
                 </v-card-actions>
               </v-card>
             </v-flex>
@@ -96,6 +96,16 @@ export default {
           this.postCategory = ''
         }
       );
+    },
+    deleteBookmark(id) {
+      if (confirm("このBookmarkを削除しますか？")) {
+        axios.delete(`/api/bookmarks/${id}`)
+          .then(response => {
+            this.setBookmark();
+          }
+        );
+      }
+      
     },
   }
 }

--- a/app/views/api/bookmarks/index.json.jbuilder
+++ b/app/views/api/bookmarks/index.json.jbuilder
@@ -1,1 +1,1 @@
-json.array! @bookmarks, :title, :url, :category
+json.array! @bookmarks, :id, :title, :url, :category

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
   }
 
   namespace :api, format: 'json' do
-    resources :bookmarks, only: [:index, :show, :create]
+    resources :bookmarks, only: [:index, :show, :create, :destroy]
   end
 end


### PR DESCRIPTION
# what
- index.json.jbuilderにてカラムのIDを渡せていなかったため、編集し、サーバーサイドとフロントサイド双方にて削除機能を実装しました。